### PR TITLE
Minor fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,16 +4,21 @@ import numpy
 from os import path
 from glob import glob
 
-
 setup(
     name="eiliftover",
     ext_modules=cythonize([Extension(path.join("eiliftover.util.contrast"),
-                                     [path.join("eiliftover", "util", "contrast.pyx")]),
-                             Extension(path.join("eiliftover.util.overlap"),
-                                       [path.join("eiliftover", "util", "overlap.pyx")]),
-                             Extension(path.join("eiliftover.alignments.cminimap"),
-                                       [path.join("eiliftover", "alignments", "cminimap.pyx")]),
-                             ]),
+                                     [path.join("eiliftover", "util", "contrast.pyx")],
+                                     include_dirs=[numpy.get_include()]
+                                     ),
+                           Extension(path.join("eiliftover.util.overlap"),
+                                     [path.join("eiliftover", "util", "overlap.pyx")],
+                                     include_dirs=[numpy.get_include()]
+                                     ),
+                           Extension(path.join("eiliftover.alignments.cminimap"),
+                                     [path.join("eiliftover", "alignments", "cminimap.pyx")],
+                                     include_dirs=[numpy.get_include()]
+                                     ),
+                           ]),
     packages=find_packages() + glob("eiliftover/"),
     include_dirs=[numpy.get_include()],
     scripts=glob("util/*.py")


### PR DESCRIPTION
multi_genome_compare.py:62 When using gffread to create BED files, lines can have > 12 fields
multi_genome_compare.py:130-131 Add a more descriptive message of the transcript causing the issue
multi_genome_compare.py:530-533 Create the index before launching child processes, fixes parallel creation issue
setup.py Fix issues with cython